### PR TITLE
fix: Replace OpenAPI linter

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
-        uses: char0n/swagger-editor-validate@v1
+        uses: swaggerexpert/swagger-editor-validate@v1
         with:
           swagger-editor-url: http://localhost/
           definition-file: docs/openapi.yaml


### PR DESCRIPTION
This replaces the deprecated OpenAPI linting action with a drop-in replacement, as the original library has changed name and is no longer maintained.