### PR TITLE
refactor: Add parameter for path to OpenAPI spec

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -19,6 +19,11 @@ on:
         type: boolean
         required: false
         default: true
+      openapi_definition:
+        description: "Path to the OpenAPI definition file"
+        type: string
+        required: false
+        default: "docs/openapi.yaml"
       lint_cloudformation:
         description: "Run linter for CloudFormation template"
         type: boolean
@@ -68,7 +73,7 @@ jobs:
         uses: swaggerexpert/swagger-editor-validate@v1
         with:
           swagger-editor-url: http://localhost/
-          definition-file: docs/openapi.yaml
+          definition-file: ${{ inputs.openapi_definition }}
 
   dependency-submission:
     name: Dependency graph


### PR DESCRIPTION
Adds an optional parameter for the path to OpenAPI definition file, as some repositories name this differently. The current default is set as the default value of the parameter, so it should not be a breaking change for other callers.