### PR TITLE
ci: Bump setup-gradle to v4

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -110,7 +110,7 @@ jobs:
           distribution: ${{ inputs.java_distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"


### PR DESCRIPTION
Bumps `gradle/actions/setup-gradle` from v3 to v4. This seems to fix issues with caching Gradle builds. From what I can tell from the release notes, this is not a breaking change (for us), so no further changes should be necessary.