### PR TITLE
ci: Pin and upgrade versions

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup CloudFormation Linter
-        uses: scottbrenner/cfn-lint-action@v2
+        uses: scottbrenner/cfn-lint-action@9636da81fb2e0cef75725d8dda11b0148940b7ae # v.2.6.0
 
       - name: Run CloudFormation linter
         run: |
@@ -91,7 +91,7 @@ jobs:
           distribution: ${{ inputs.java_distribution }}
 
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4
+        uses: gradle/actions/dependency-submission@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
@@ -110,7 +110,7 @@ jobs:
           distribution: ${{ inputs.java_distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
@@ -121,13 +121,13 @@ jobs:
         run: ./gradlew build --info
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: always()
         with:
           files: "**/build/test-results/**/*.xml"
 
       - name: Codacy Coverage Reporter
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           project-token: ${{ secrets.codacy_token }}
           coverage-reports: $(pwd)/${{ inputs.code_coverage_report_path }}


### PR DESCRIPTION
Changes:

- Pins the versions of third-party actions to a specific SHA to reduce the risk of supply chain attacks, as recommended by GitHub
- Upgrades `gradle/actions` to `v5.0.2`