### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  # Update GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+
+  # Update Gradle dependencies (version catalogs + build plugins)
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+    # Groups help reduce PR noise by batching related updates
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 
 updates:
-  # Update GitHub Actions workflows
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -10,8 +9,6 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
-
-  # Update Gradle dependencies (version catalogs + build plugins)
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
@@ -20,7 +17,6 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
-    # Groups help reduce PR noise by batching related updates
     groups:
       patch-updates:
         update-types:


### PR DESCRIPTION
Configured Dependabot to update GitHub Actions and Gradle dependencies weekly with specified cooldown and grouping for updates.

Cooldown helps us avoid supply chain attacks.

Note: we should consider renovate since dependabot has gradle issues and I am unconvinced that it supports distributed version catalogues.